### PR TITLE
Adjusted Directory Services Event Channel Entry

### DIFF
--- a/nxlog.conf
+++ b/nxlog.conf
@@ -218,7 +218,7 @@ LogFile %LOGFILE%
                             <Select Path="Microsoft-Windows-AppLocker/MSI and Script">*</Select>\
                             <Select Path="Microsoft-Windows-AppLocker/Packaged app-Deployment">*</Select>\
                             <Select Path="Microsoft-Windows-AppLocker/Packaged app-Execution">*</Select>\
-                            <Select Path="Microsoft-Windows-Directory Service">*</Select>\
+                            <Select Path="Directory Service">*</Select>\
                             <Select Path="Microsoft-Windows-DNS-Client/Operational">*</Select>\
                             <Select Path="Microsoft-Windows-GroupPolicy/Operational">*</Select>\
                             <Select Path="Microsoft-Windows-Kernel-PnP/Configuration">*</Select>\


### PR DESCRIPTION
```<Select Path="Microsoft-Windows-Directory Service">*</Select>\``` fails to enumerate the event channel route, which generates the 15007 error code. 

Updated to use the correct channel name: ```<Select Path="Directory Service">*</Select>\```

See Git Diff.